### PR TITLE
Adds patches for Macbook M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Invoke-WebRequest -UseBasicParsing `
 
 ### Prerequisities
 
-MacOs:
+MacOS:
 * GNU utilities are required to run this script, you can follow the how-to at: https://gist.github.com/skyzyx/3438280b18e4f7c490db8a2a2ca0b9da
 
 Linux / MacOS:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Invoke-WebRequest -UseBasicParsing `
 
 ### Prerequisities
 
+MacOs:
+* GNU utilities are required to run this script, you can follow the how-to at: https://gist.github.com/skyzyx/3438280b18e4f7c490db8a2a2ca0b9da
+
 Linux / MacOS:
 
 * `bash` for executing script

--- a/install-hashicorp.sh
+++ b/install-hashicorp.sh
@@ -45,14 +45,18 @@ install_hashicorp_binaries(){
         sunos*) os='solaris';;
     esac
     # Look up the architecture
-    if [ "$(uname -m)" = "x86_64" ] && [ "$(getconf LONG_BIT)" = "64" ]; then
-        arch="amd64"
-    elif [ "$(uname -m)" = "x86_64" ] && [ "$(getconf LONG_BIT)" = "32" ]; then
-        arch="386"
-    elif [[ "$(uname -m)" =~ (aarch|arm) ]] && [ "$(getconf LONG_BIT)" = "64" ]; then
-        arch="arm64"
-    elif [[ "$(uname -m)" =~ "arm" ]] && [ "$(getconf LONG_BIT)" = "32" ]; then
-        arch="arm"
+    if [ "$(getconf LONG_BIT)" = "64" ]; then
+        if [ "$(uname -m)" = "x86_64" ]; then
+            arch="amd64"
+        elif [[ "$(uname -m)" =~ ^.*(arm|aarch).*$ ]]; then
+            arch="arm64"
+        fi
+    elif  [ "$(getconf LONG_BIT)" = "32" ]; then
+        if [ "$(uname -m)" = "x86_64" ]; then
+            arch="386"
+        elif [[ "$(uname -m)" =~ ^.*arm.*$ ]]; then
+            arch="arm"
+        fi
     fi
     # Verify the system requirements
     local cmds=(shasum sha256sum curl unzip gpg) cmds_error="" gpg=0 shasum=0

--- a/install-hashicorp.sh
+++ b/install-hashicorp.sh
@@ -53,6 +53,8 @@ install_hashicorp_binaries(){
         arch="arm64"
     elif [[ "$(uname -m)" =~ "arm" ]] && [ "$(getconf LONG_BIT)" = "32" ]; then
         arch="arm"
+    elif [[ "$(uname -m)" =~ "arm" ]] && [ "$(getconf LONG_BIT)" = "64" ]; then
+        arch="arm64"
     fi
     # Verify the system requirements
     local cmds=(shasum sha256sum curl unzip gpg) cmds_error="" gpg=0 shasum=0
@@ -154,7 +156,7 @@ install_hashicorp_binaries(){
         rm ${TMPDIR:-/tmp}/${name}_${version}_${os}_${arch}.zip
         # Verify the integrity of the executable (darwin only)
         if [ "${os}" = "darwin" ] &&
-            [ "${codesign_teamid}" != "$(codesign --verify -d --verbose=2 ${TMPDIR:-/tmp}/${name} |
+            [ "${codesign_teamid}" != "$(codesign --verify -d --verbose=2 ${TMPDIR:-/tmp}/${name} 2>&1 |
             sed -En 's/^TeamIdentifier=([A-Z0-9]+)$/\1/gp')" ]; then
             echo >&2 "FATAL:   Integrity of the executable \"${name}\" is compromised"
             exit 1
@@ -163,7 +165,7 @@ install_hashicorp_binaries(){
         mv -f ${TMPDIR:-/tmp}/${name} /usr/local/bin/${name}
         # Verify the installation
         verify="$(${name} version)"
-        verify="$(echo "$verify" | sed -En 's/^.*?([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' | sed -n '1p')"
+        verify="$(echo "$verify" | sed -En 's/^[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' | sed -n '1p')"
         if [ "${verify}" != "${version}" ]; then
             echo >&2 "WARNING: Another executable file is prioritized when the command \"${name}\" is executed"
             echo >&2 "         Check your system's PATH!"

--- a/install-hashicorp.sh
+++ b/install-hashicorp.sh
@@ -49,12 +49,10 @@ install_hashicorp_binaries(){
         arch="amd64"
     elif [ "$(uname -m)" = "x86_64" ] && [ "$(getconf LONG_BIT)" = "32" ]; then
         arch="386"
-    elif [[ "$(uname -m)" =~ "aarch" ]] && [ "$(getconf LONG_BIT)" = "64" ]; then
+    elif [[ "$(uname -m)" =~ (aarch|arm) ]] && [ "$(getconf LONG_BIT)" = "64" ]; then
         arch="arm64"
     elif [[ "$(uname -m)" =~ "arm" ]] && [ "$(getconf LONG_BIT)" = "32" ]; then
         arch="arm"
-    elif [[ "$(uname -m)" =~ "arm" ]] && [ "$(getconf LONG_BIT)" = "64" ]; then
-        arch="arm64"
     fi
     # Verify the system requirements
     local cmds=(shasum sha256sum curl unzip gpg) cmds_error="" gpg=0 shasum=0
@@ -165,7 +163,7 @@ install_hashicorp_binaries(){
         mv -f ${TMPDIR:-/tmp}/${name} /usr/local/bin/${name}
         # Verify the installation
         verify="$(${name} version)"
-        verify="$(echo "$verify" | sed -En 's/^[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' | sed -n '1p')"
+        verify="$(echo "$verify" | sed -En 's/^.*?([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' | sed -n '1p')"
         if [ "${verify}" != "${version}" ]; then
             echo >&2 "WARNING: Another executable file is prioritized when the command \"${name}\" is executed"
             echo >&2 "         Check your system's PATH!"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
* MacOS users need to install GNU utilities as described in the Gist linked in the [README.md](README.md)
* Added arm64 as valid output from `uname -m` on Apple M1 computers.
* codesign prints output to STDERR, so needed to catch that.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
