### PR TITLE
overwrite unzipped

### DIFF
--- a/install-hashicorp.sh
+++ b/install-hashicorp.sh
@@ -150,7 +150,7 @@ install_hashicorp_binaries(){
         # Clean up the checksums file
         rm ${TMPDIR:-/tmp}/${name}_${version}_SHA256SUMS
         # Extract the archive
-        unzip ${TMPDIR:-/tmp}/${name}_${version}_${os}_${arch}.zip -d ${TMPDIR:-/tmp} >/dev/null
+        unzip -o ${TMPDIR:-/tmp}/${name}_${version}_${os}_${arch}.zip -d ${TMPDIR:-/tmp} >/dev/null
         chmod +x ${TMPDIR:-/tmp}/${name}
         # Clean up the archive
         rm ${TMPDIR:-/tmp}/${name}_${version}_${os}_${arch}.zip


### PR DESCRIPTION
##### SUMMARY
The script fails when running multiple times for the same package&version as it requires user input.
Therefore allowing overwrite for the unzip command.

One could also check the installed package and check if it equals the one to install, with a check e.g. for terraform:

`terraform version -json | jq -r '.terraform_version'`

which might be difficult when having the package name generic for hashicorps installables.


