### PR TITLE
Make the linux system path check less immersive

### DIFF
--- a/install-hashicorp.sh
+++ b/install-hashicorp.sh
@@ -202,14 +202,14 @@ install_hashicorp_binaries(){
         # Add the executable to the specified directory
         mv -f "${tmp_dir}/${name}" "${install_dir}/${name}"
         # Verify the installation
-        verify="$("${install_dir}/"${name} version | sed -En 's/^.*([0-9]+\.[0-9]+\.[0-9]+[0-9a-zA-Z\.+-]*).*$/\1/p' | sed -n '1p' || true)"
+        verify="$("${install_dir}/"${name} version 2>/dev/null | sed -En 's/^.*([0-9]+\.[0-9]+\.[0-9]+[0-9a-zA-Z\.+-]*).*$/\1/p' | sed -n '1p' || true)"
         if [ "${verify}" != "${version}" ]; then
             echo >&2 "ERROR:   Verifying the installed version failed."
             exit 1
         fi
-        verify="$(${name} version | sed -En 's/^.*([0-9]+\.[0-9]+\.[0-9]+[0-9a-zA-Z\.+-]*).*$/\1/p' | sed -n '1p' || true)"
+        verify="$(${name} version 2>/dev/null | sed -En 's/^.*([0-9]+\.[0-9]+\.[0-9]+[0-9a-zA-Z\.+-]*).*$/\1/p' | sed -n '1p' || true)"
         if [ "${verify}" != "${version}" ]; then
-            echo >&2 "WARNING: Command \"${name}\" is not using installed version. Check the system's PATH!"
+            echo "INFO: Command \"${name}\" is not using installed binary. Check the system's PATH!"
         fi
     done
     rm -rf "$tmp_dir"

--- a/install-hashicorp.sh
+++ b/install-hashicorp.sh
@@ -209,7 +209,7 @@ install_hashicorp_binaries(){
         fi
         verify="$(${name} version 2>/dev/null | sed -En 's/^.*([0-9]+\.[0-9]+\.[0-9]+[0-9a-zA-Z\.+-]*).*$/\1/p' | sed -n '1p' || true)"
         if [ "${verify}" != "${version}" ]; then
-            echo "INFO: Command \"${name}\" is not using installed binary. Check the system's PATH!"
+            echo "INFO: Command \"${name}\" is not using installed version. Check the system's PATH!"
         fi
     done
     rm -rf "$tmp_dir"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Make linux related system path verification after installation less immersive by changing it to an INFO piped to the STDOUT.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
